### PR TITLE
Add inline-fold.nvim plugin for enhanced code folding

### DIFF
--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -48,6 +48,7 @@
   "hydra.nvim": { "branch": "master", "commit": "55de54543d673824435930ecf533256eea2e565b" },
   "indent-blankline.nvim": { "branch": "master", "commit": "259357fa4097e232730341fa60988087d189193a" },
   "keymap-amend.nvim": { "branch": "master", "commit": "b8bf9d820878d5497fdd11d6de55dea82872d98e" },
+  "inline-fold.nvim": { "branch": "main", "commit": "d0a24dd55c2fe9477e2636a589499fb7d530e9a3" },
   "lazy.nvim": { "branch": "main", "commit": "7e6c863bc7563efbdd757a310d17ebc95166cef3" },
   "lazydev.nvim": { "branch": "main", "commit": "f59bd14a852ca43db38e3662395354cb2a9b13e0" },
   "lazydocker.nvim": { "branch": "main", "commit": "404061ec122e4782d12d04d4cdbb74ad3fc42c26" },

--- a/lua/plugins/buffer-ui.lua
+++ b/lua/plugins/buffer-ui.lua
@@ -43,7 +43,7 @@ return {
 	},
 	{
 		"malbertzard/inline-fold.nvim",
-		lazy = false,
+		cmd = { "InlineFoldToggle" },
 		opts = function(_, opts)
 			opts.defaultPlaceholder = "…"
 			if not opts.queries then

--- a/lua/plugins/buffer-ui.lua
+++ b/lua/plugins/buffer-ui.lua
@@ -42,6 +42,32 @@ return {
 		end,
 	},
 	{
+		"malbertzard/inline-fold.nvim",
+		lazy = false,
+		opts = function(_, opts)
+			opts.defaultPlaceholder = "…"
+			if not opts.queries then
+				opts.queries = {
+					html = {
+						{ pattern = 'class="([^"]*)"' },
+						{ pattern = 'className="([^"]*)"' },
+						{ pattern = 'href="(.-)"' },
+						{ pattern = 'src="(.-)"' },
+					},
+				}
+			end
+
+			for _, language in ipairs(require("utils.constants").filetype.javascript) do
+				opts.queries[language] = {
+					{ pattern = 'className="([^"]*)"' },
+					{ pattern = 'href="(.-)"' },
+					{ pattern = 'src="(.-)"' },
+				}
+			end
+			return opts
+		end,
+	},
+	{
 		"anuvyklack/fold-preview.nvim",
 		event = "VeryLazy",
 		dependencies = "anuvyklack/keymap-amend.nvim",

--- a/lua/plugins/command-palette.lua
+++ b/lua/plugins/command-palette.lua
@@ -62,6 +62,7 @@ return {
 						"File",
 						{ "Toggle env variables", "CloakToggle" },
 						{ "View on GitHub", ":lua Snacks.gitbrowse()" },
+						{ "Toggle inline folds", ":InlineFoldToggle" },
 						{ "Search and Replace", ":SearchAndReplace" },
 						{ "Inspect types", ":InspectTwoslashQueries" },
 					},


### PR DESCRIPTION
- Added `malbertzard/inline-fold.nvim` plugin to `buffer-ui.lua`.
- Configured default placeholder and queries for HTML and JavaScript.
- Updated `lazy-lock.json` with the new plugin commit.
- Added command to toggle inline folds in `command-palette.lua`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added `inline-fold.nvim` plugin for enhanced code folding.
	- Introduced a new command to toggle inline folds in the command palette.

- **Chores**
	- Updated `lazy-lock.json` with new plugin entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->